### PR TITLE
Unsupervised frozen wheel cache

### DIFF
--- a/viral/cache_2p_sessions.py
+++ b/viral/cache_2p_sessions.py
@@ -663,23 +663,14 @@ def check_against_suite2p_output(
 def main() -> None:
     """TODO: Can probably deprecate this as it's superceded by learning_stages.py"""
 
-    # for mouse_name in ["JB017", "JB019", "JB020", "JB021", "JB022", "JB023"]:
-    redo = True
-    for mouse_name in ["JB031"]:
+    redo = False
+    for mouse_name in ["JB030", "JB031", "JB032", "JB033", "JB034", "JB035"]:
         metadata = gsheet2df(SPREADSHEET_ID, mouse_name, 1)
         for _, row in metadata.iterrows():
-
             try:
-                print(f"the type is {row['Type']}")
-
+                print(f"The type is {row['Type']}")
                 date = row["Date"]
                 session_type = row["Type"].lower()
-                try:
-                    wheel_blocked = row["Wheel blocked?"].lower() == "yes"
-                except KeyError as e:
-                    print(f"No column 'Wheel blocked?' found: {e}")
-                    print("Wheel blocked set to None")
-                    wheel_blocked = None
                 if (
                     not redo
                     and (
@@ -689,13 +680,15 @@ def main() -> None:
                     print(f"Skipping {mouse_name} {date} as already exists")
                     continue
 
-                if (
-                    "learning day" not in session_type
-                    and "reversal learning" not in session_type
-                ):
+                if "learning" not in session_type:
                     print(f"Skipping {mouse_name} {date} {session_type}")
                     continue
-
+                try:
+                    wheel_blocked = row["Wheel blocked?"].lower() in {"yes", "true"}
+                except KeyError as e:
+                    print(f"No column 'Wheel blocked?' found: {e}")
+                    print("Wheel blocked set to None")
+                    wheel_blocked = None
                 if not row["Sync file"]:
                     print(
                         f"Skipping {mouse_name} {date} {session_type} as no sync file"

--- a/viral/correct_2p_sessions.py
+++ b/viral/correct_2p_sessions.py
@@ -1,4 +1,8 @@
-"""For some sessions, focussing without grabbing or late start of the DAQ occured, requiring manual fixing."""
+"""cache_2p_sessions.py is responsible for adding frame stamps and time stamps to behavioural event data.
+It processes imaging files (.tiff), behavioural events (trial.json), and the corresponding synchronisation file (DAQami) as inputs,
+performing a series of checks before appending this information.
+However, a range of user-dependent or experimental circumstances can occasionally cause the caching process to fail.
+In these cases, manual correction is required."""
 
 import sys
 import numpy as np
@@ -38,7 +42,7 @@ def apply_session_correction(
     if (mouse_name, date) in session_corrections:
         print("Applying manual session corrections")
         correction_func = session_corrections[(mouse_name, date)]
-        return correction_func(
+        c = correction_func(
             SessionCorrection(
                 epochs=epochs,
                 all_tiff_timestamps=all_tiff_timestamps,
@@ -48,6 +52,18 @@ def apply_session_correction(
                 offset_after_pre_epoch=0,
             )
         )
+        assert sum(c.chunk_lengths_daq) == len(c.frame_times_daq)
+        # I found a bug where if you deleted a column of the epochs array in a session correction,
+        # all the assertions would pass and save the session cache regardless.
+        # It is fixed now, but these assertions are here to ensure it does not happen again.
+        assert c.epochs.shape[0] == len(
+            c.stack_lengths_tiffs
+        ), "There should be one epoch per tiff stack"
+        assert (
+            c.epochs.shape[1] == 6
+        ), "Each epoch should have 6 values (year, month, ...)"
+        return c
+
     return SessionCorrection(
         epochs=epochs,
         all_tiff_timestamps=all_tiff_timestamps,
@@ -56,6 +72,24 @@ def apply_session_correction(
         frame_times_daq=frame_times_daq,
         offset_after_pre_epoch=0,
     )
+
+
+# epochs:               (n_tiffs, 6);   start time of each tiff file (they are in a matlab format, hence each epoch has 6 values)
+# all_tiff_timestamps:  (n_frames);     timestamps of each frame in all tiff files (in seconds since start of the DAQ)
+# stack_lengths_tiffs:  (n_tiffs,);     length of each tiff stack (in frames)
+# chunk_lengths_daq:    (n_chunks,);    length of each daq chunk (in frames), i.e. all frame pulses emitted by the frame clock and recorded by the DAQ
+# frame_times_daq:      (n_frames,);    timestamps of each frame in the DAQ (in time units of the DAQ, usually 10000 Hz, but depending on the DAQ sampling rate)
+
+# In principle, the following rules apply to all sessions and are either checked by assertions directly or will cause other assertions to fail:
+# 1. sum(chunk_lengths_daq) == len(frame_times_daq), i.e. total number of frames in the DAQ must match total number of frame timestamps
+# 2. epochs.shape[0] == len(stack_lengths_tiffs), i.e. there must be one epoch per tiff stack
+# 3. for each chunk of imaging, the chunk_length_daq can be 0-3 frames short of stack_length_tiff (see get_valid_frame_times())
+
+# So, if applying certain corrections, it must be ensured that the above rules are still satisfied.
+# See explanations in the individual corrections below.
+
+
+# Session corrections ordered by mouse name and date.
 
 
 @register_correction("JB031", "2025-03-31")
@@ -78,7 +112,6 @@ def jb031_2025_03_31(c: SessionCorrection) -> SessionCorrection:
     bad_daq_len_pre = sum([1325, 3224, 147])
     bad_daq_len_post = 657
     c.frame_times_daq = c.frame_times_daq[bad_daq_len_pre:-bad_daq_len_post]
-    assert sum(c.chunk_lengths_daq) == len(c.frame_times_daq)
     # TODO: the last chunk is shorter than 15 mins / 27,000 frames, do we need to remove the session?
     return SessionCorrection(
         epochs=c.epochs,
@@ -90,6 +123,8 @@ def jb031_2025_03_31(c: SessionCorrection) -> SessionCorrection:
     )
 
 
+# Ex.: classic case of manual 'focus' without grabbing, resulting in a tiff stack with no associated DAQ chunk.
+# The signals in the DAQ files have to be deleted, i.e. in chunk_lengths_daq and frame_times_daq.
 @register_correction("JB031", "2025-04-01")
 def jb031_2025_04_01(c: SessionCorrection) -> SessionCorrection:
     # stack_lengths_tiffs
@@ -110,6 +145,10 @@ def jb031_2025_04_01(c: SessionCorrection) -> SessionCorrection:
     )
 
 
+# Ex.: Classic case of starting the DAQ after the pre-session epoch, resulting in a tiff stack with no associated DAQ chunk.
+# The first tiff has to be removed from the syncing, i.e. in stack_lengths_tiffs, all_tiff_timestamps and epochs.
+# The 'offset_after_pre_epoch' is set to the length of the first tiff stack,
+# so that the DAQ signals keep on being aligned while the pre_session_epoch will be skipped.
 @register_correction("JB031", "2025-04-02")
 def jb031_2025_04_02(c: SessionCorrection) -> SessionCorrection:
     # stack_lengths_tiffs
@@ -145,7 +184,6 @@ def jb031_2025_04_03(c: SessionCorrection) -> SessionCorrection:
             ],
         ]
     )
-    assert sum(c.chunk_lengths_daq) == len(c.frame_times_daq)
     return SessionCorrection(
         epochs=c.epochs,
         all_tiff_timestamps=c.all_tiff_timestamps,
@@ -156,6 +194,8 @@ def jb031_2025_04_03(c: SessionCorrection) -> SessionCorrection:
     )
 
 
+# Ex.: Classic case of hitting 'focus' without grabbing before the session.
+# Again, the signals in the DAQ files have to be deleted, i.e. in chunk_lengths_daq and frame_times_daq.
 @register_correction("JB031", "2025-04-04")
 def jb031_2025_04_04(c: SessionCorrection) -> SessionCorrection:
     # stack_lengths_tiffs
@@ -164,7 +204,6 @@ def jb031_2025_04_04(c: SessionCorrection) -> SessionCorrection:
     # array([   104,  27000, 108945,  27000])
     c.chunk_lengths_daq = np.delete(c.chunk_lengths_daq, 0)
     c.frame_times_daq = c.frame_times_daq[104:]
-    assert sum(c.chunk_lengths_daq) == len(c.frame_times_daq)
     return SessionCorrection(
         epochs=c.epochs,
         all_tiff_timestamps=c.all_tiff_timestamps,
@@ -174,6 +213,46 @@ def jb031_2025_04_04(c: SessionCorrection) -> SessionCorrection:
         offset_after_pre_epoch=0,
     )
 
+
+@register_correction("JB032", "2025-03-27")
+def jb032_2025_03_27(c: SessionCorrection) -> SessionCorrection:
+    # stack_lengths_tiffs
+    # array([ 27000,   6319, 104990,  12172,  27000,    113])
+    # chunk_lengths_daq
+    # array([ 27000,   6321, 104992,  12174,    868,  27000,    115])
+    # TODO: check if all of this makes sense??
+    # Deleting last tiff after post epoch, getting rid of focus w/o grabbing before post epoch
+    c.stack_lengths_tiffs = np.delete(c.stack_lengths_tiffs, [5])
+    c.epochs = np.delete(c.epochs, [5], axis=0)
+    c.all_tiff_timestamps = np.delete(c.all_tiff_timestamps, [5])
+    c.chunk_lengths_daq = np.delete(c.chunk_lengths_daq, [4, 6])
+    c.frame_times_daq = np.concatenate(
+        [
+            c.frame_times_daq[0 : sum([27000, 6321, 104992, 12174])],
+            c.frame_times_daq[
+                sum([27000, 6321, 104992, 12174, 868]) : sum(
+                    [27000, 6321, 104992, 12174, 868, 27000]
+                )
+            ],
+        ]
+    )
+    return SessionCorrection(
+        epochs=c.epochs,
+        all_tiff_timestamps=c.all_tiff_timestamps,
+        stack_lengths_tiffs=c.stack_lengths_tiffs,
+        chunk_lengths_daq=c.chunk_lengths_daq,
+        frame_times_daq=c.frame_times_daq,
+        offset_after_pre_epoch=0,
+    )
+
+# @register_correction("JB032", "2025-03-31")
+# def jb032_2025_03_31(c: SessionCorrection) -> SessionCorrection:
+    # stack_lengths_tiffs
+    # array([27000, 30111,  8106, 71221])
+    # chunk_lengths_daq
+    # array([30113,  8108, 71223])
+    # TODO: keep this session at all, or superceed as wheel_blocked false??
+    # Super messy session! DAQ started after the pre epoch, no post epoch ("Didn't bother with the post freeze as no active behaviour")
 
 @register_correction("JB032", "2025-04-01")
 def jb032_2025_04_01(c: SessionCorrection) -> SessionCorrection:
@@ -207,7 +286,47 @@ def jb032_2025_04_01(c: SessionCorrection) -> SessionCorrection:
             ],
         ]
     )
-    assert sum(c.chunk_lengths_daq) == len(c.frame_times_daq)
+    return SessionCorrection(
+        epochs=c.epochs,
+        all_tiff_timestamps=c.all_tiff_timestamps,
+        stack_lengths_tiffs=c.stack_lengths_tiffs,
+        chunk_lengths_daq=c.chunk_lengths_daq,
+        frame_times_daq=c.frame_times_daq,
+        offset_after_pre_epoch=0,
+    )
+
+
+@register_correction("JB033", "2025-03-20")
+def jb033_2025_03_20(c: SessionCorrection) -> SessionCorrection:
+    # stack_lengths_tiffs
+    # array([  3215,    464,  28014, 122997,    105,  29148])
+    # chunk_lengths_daq
+    # array([   466,  28016, 122999,    107,  29151])
+    # Deleting the first two grabs (3215; 464, 466 respectively) before the pre epoch
+    c.stack_lengths_tiffs = np.delete(c.stack_lengths_tiffs, [0, 1])
+    c.epochs = np.delete(c.epochs, [0, 1], axis=0)
+    c.chunk_lengths_daq = np.delete(c.chunk_lengths_daq, [0])
+    c.frame_times_daq = c.frame_times_daq[466:]
+    c.all_tiff_timestamps = c.all_tiff_timestamps[3215 + 464 :]
+    return SessionCorrection(
+        epochs=c.epochs,
+        all_tiff_timestamps=c.all_tiff_timestamps,
+        stack_lengths_tiffs=c.stack_lengths_tiffs,
+        chunk_lengths_daq=c.chunk_lengths_daq,
+        frame_times_daq=c.frame_times_daq,
+        offset_after_pre_epoch=0,
+    )
+
+
+@register_correction("JB033", "2025-06-17")
+def jb033_2025_06_17(c: SessionCorrection) -> SessionCorrection:
+    # stack_lengths_tiffs
+    # array([ 1165, 27000, 54293, 17594, 49112, 27000])
+    # chunk_lengths_daq
+    # array([27000, 54295, 17596, 49115, 27000])
+    c.stack_lengths_tiffs = np.delete(c.stack_lengths_tiffs, [0])
+    c.epochs = np.delete(c.epochs, [0], axis=0)
+    c.all_tiff_timestamps = c.all_tiff_timestamps[1165:]
     return SessionCorrection(
         epochs=c.epochs,
         all_tiff_timestamps=c.all_tiff_timestamps,

--- a/viral/correct_2p_sessions.py
+++ b/viral/correct_2p_sessions.py
@@ -224,7 +224,9 @@ def jb032_2025_03_27(c: SessionCorrection) -> SessionCorrection:
     # Deleting last tiff after post epoch, getting rid of focus w/o grabbing before post epoch
     c.stack_lengths_tiffs = np.delete(c.stack_lengths_tiffs, [5])
     c.epochs = np.delete(c.epochs, [5], axis=0)
-    c.all_tiff_timestamps = np.delete(c.all_tiff_timestamps, [5])
+    c.all_tiff_timestamps = c.all_tiff_timestamps[
+        : sum([27000, 6319, 104990, 12172, 27000])
+    ]
     c.chunk_lengths_daq = np.delete(c.chunk_lengths_daq, [4, 6])
     c.frame_times_daq = np.concatenate(
         [
@@ -245,14 +247,6 @@ def jb032_2025_03_27(c: SessionCorrection) -> SessionCorrection:
         offset_after_pre_epoch=0,
     )
 
-# @register_correction("JB032", "2025-03-31")
-# def jb032_2025_03_31(c: SessionCorrection) -> SessionCorrection:
-    # stack_lengths_tiffs
-    # array([27000, 30111,  8106, 71221])
-    # chunk_lengths_daq
-    # array([30113,  8108, 71223])
-    # TODO: keep this session at all, or superceed as wheel_blocked false??
-    # Super messy session! DAQ started after the pre epoch, no post epoch ("Didn't bother with the post freeze as no active behaviour")
 
 @register_correction("JB032", "2025-04-01")
 def jb032_2025_04_01(c: SessionCorrection) -> SessionCorrection:

--- a/viral/imaging_utils.py
+++ b/viral/imaging_utils.py
@@ -2,7 +2,6 @@
 
 from scipy.ndimage import gaussian_filter1d
 from typing import List, Tuple
-import os
 import numpy as np
 from viral.models import TrialInfo
 from viral.utils import (
@@ -35,7 +34,7 @@ def load_imaging_data(
     if not (s2p_path / "oasis_spikes.npy").exists():
         from viral.run_oasis import main as run_oasis
 
-        run_oasis(mouse=mouse, date=date, grosmark=True)
+        run_oasis(mouse=mouse, date=date, grosmark=False)
     iscell = np.load(s2p_path / "iscell.npy")[:, 0].astype(bool)
 
     spks = np.load(s2p_path / "oasis_spikes.npy")[iscell, :]

--- a/viral/imaging_utils.py
+++ b/viral/imaging_utils.py
@@ -30,9 +30,9 @@ def load_imaging_data(
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
     s2p_path = TIFF_UMBRELLA / date / mouse / "suite2p" / "plane0"
     print(f"Suite 2p path is {s2p_path}")
-    if not os.path.exists(s2p_path):
+    if not s2p_path.exists():
         raise FileNotFoundError("This session likely was not suite2p'ed yet")
-    if not os.path.exists(s2p_path / "oasis_spikes.npy"):
+    if not (s2p_path / "oasis_spikes.npy").exists():
         from viral.run_oasis import main as run_oasis
 
         run_oasis(mouse=mouse, date=date, grosmark=True)

--- a/viral/imaging_utils.py
+++ b/viral/imaging_utils.py
@@ -2,6 +2,7 @@
 
 from scipy.ndimage import gaussian_filter1d
 from typing import List, Tuple
+import os
 import numpy as np
 from viral.models import TrialInfo
 from viral.utils import (
@@ -29,6 +30,12 @@ def load_imaging_data(
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
     s2p_path = TIFF_UMBRELLA / date / mouse / "suite2p" / "plane0"
     print(f"Suite 2p path is {s2p_path}")
+    if not os.path.exists(s2p_path):
+        raise FileNotFoundError("This session likely was not suite2p'ed yet")
+    if not os.path.exists(s2p_path / "oasis_spikes.npy"):
+        from viral.run_oasis import main as run_oasis
+
+        run_oasis(mouse=mouse, date=date, grosmark=True)
     iscell = np.load(s2p_path / "iscell.npy")[:, 0].astype(bool)
 
     spks = np.load(s2p_path / "oasis_spikes.npy")[iscell, :]
@@ -307,4 +314,5 @@ def get_imaging_crashed(mouse_name: str, date: str) -> bool:
     return (mouse_name, date) in [
         ("JB011", "2024-10-22"),
         ("JB011", "2024-10-25"),
+        ("JB034", "2025-07-04"),
     ]


### PR DESCRIPTION
Cleaned up cache2p sessions, added oasis step, made sure unsupervised… wheel freeze can be cached

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded processing to include multiple mice for session caching.
  * Improved detection and handling of missing imaging data by automatically generating required files if absent.
  * Updated list of sessions flagged for crashed imaging.
  * Added new manual corrections for imaging session data to improve accuracy and alignment.

* **Bug Fixes**
  * Enhanced logic for identifying session types and handling wheel-blocked status, improving data reliability.
  * Added validation checks to prevent subtle data misalignments in session corrections.

* **Chores**
  * Added additional checks and error handling for missing directories and files.
  * Improved documentation and comments explaining session correction processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->